### PR TITLE
Added a note about netpols enforcement

### DIFF
--- a/f.services.md
+++ b/f.services.md
@@ -183,6 +183,8 @@ kubectl delete deploy foo
 
 kubernetes.io > Documentation > Concepts > Services, Load Balancing, and Networking > [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
 
+> Note that network policies may not be enforced by default, depending on your k8s implementation. E.g. Azure AKS by default won't have policy enforcement, the cluster must be created with an explicit support for `netpol` https://docs.microsoft.com/en-us/azure/aks/use-network-policies#overview-of-network-policy  
+  
 <details><summary>show</summary>
 <p>
 


### PR DESCRIPTION
To save folks some previous cycles and head banging - the example won't work with a default AKS cluster, as an example. Ie. everything gets created, but traffic flows uninterrupted.